### PR TITLE
Port LLM prompt templates from Python to Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod config;
 pub mod engines;
 pub mod loader;
 pub mod path_utils;
+pub mod prompts;
 pub mod types;

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -1,0 +1,632 @@
+use std::sync::LazyLock;
+
+use crate::config::{RARE_TYPES, VULN_TYPES};
+use crate::types::{Candidate, ContestContext, FileContext, SAFinding};
+
+// Budget for inlined contract sources in project prompt, sized to stay within LLM context limits
+const PROJECT_SOURCE_CHAR_LIMIT: usize = 60_000;
+
+const DEFAULT_SYSTEM: &str = "You are a senior smart contract security auditor performing a Code4rena-style audit.
+Your job: find REAL High and Medium severity vulnerabilities. Both missed findings and false positives reduce your score equally.
+Focus on exploitable bugs, not code style or gas optimizations. Be thorough across all vulnerability categories.";
+
+const DEFAULT_FILE_ANALYSIS: &str = r#"Analyze this Solidity file for security vulnerabilities.
+
+## Vulnerability Categories (use EXACTLY one of these):
+{vuln_types}
+
+## Contract Metadata (from IR):
+{ir_summary}
+
+## Static Analysis Flags (pre-computed, may be false positives):
+{sa_findings}
+
+## Symbolic Execution Insights:
+{symbolic_summary}
+
+## Source Code ({filepath}):
+```solidity
+{source}
+```
+
+## Classification guidance (use the MOST SPECIFIC type, not the broadest):
+- "Reentrancy": state changes AFTER external calls, cross-function reentrancy, read-only reentrancy. Classify here even if tokens are involved.
+- "Access Control": missing modifiers, broken auth, unauthorized access, privilege escalation, missing onlyOwner
+- "Token Handling": any bug where the core issue is about token/ETH value flows: incorrect fee calculations, wrong balance accounting, missing refunds, stuck rewards, fee-on-transfer not handled, wrong ERC20/ERC721 interface, missing return value check on transfer(), incorrect share/amount math in vaults
+- "Logic Error": wrong conditions, off-by-one, incorrect comparisons, flawed math formulas, wrong operator in NON-token contexts (e.g., governance logic, configuration, scheduling)
+- "DoS": unbounded loops, gas griefing, blocking operations, bricked functionality, reverting fallbacks
+- "Price Manipulation": oracle manipulation, flash loan attack vectors, TWAP manipulation, spot price dependency
+- "Front-running": sandwich attacks, MEV extraction, transaction ordering dependence, sniping
+- "Integer Overflow/Underflow": unsafe downcasts, unchecked arithmetic in Solidity <0.8, overflow in multiplication before division, precision loss from division truncation
+- "Funds Loss": locked ether, arbitrary send, irreversible loss of user funds, stuck ETH with no withdrawal
+- "State Management": uninitialized storage, stale/inconsistent state across contracts, storage collision
+- "Input Validation": missing validation at external boundaries, unchecked user inputs, missing zero-address checks
+- "Centralization Risk": single point of failure, admin can rug, privileged roles without timelock
+- "Other": timestamp dependence, block randomness, anything not fitting above categories
+
+## Instructions:
+1. For each static analysis flag, determine if it's a REAL exploitable vulnerability or a false positive.
+2. Systematically consider ALL vulnerability categories above. Look for issues the static analysis MISSED.
+3. Only report High or Medium severity. Skip Low/Informational.
+4. CLASSIFICATION RULES (strict):
+   - Token/ETH value flows (fees, balances, rewards, shares, minting, burning, refunds, stuck funds) -> ALWAYS "Token Handling"
+   - State changes after external calls -> ALWAYS "Reentrancy" (even if tokens involved)
+   - "Logic Error" is ONLY for non-token logic (governance, config, scheduling, access patterns)
+   - Missing/broken modifiers, unauthorized access -> "Access Control" (not "Centralization Risk")
+5. Report EACH distinct vulnerability separately. A typical contract yields 1-5 findings; complex protocols may have more.
+6. Both missed findings and false positives cost equally. Report every plausibly exploitable High/Medium issue where you can describe a concrete exploit path. Skip only issues you cannot articulate an exploit for.
+
+Output a JSON array of findings. If no vulnerabilities, output [].
+Each finding:
+```json
+[
+  {{
+    "file": "{filepath}",
+    "vulnerability_type": "one of the categories above",
+    "secondary_type": "optional: if the bug could also be classified as another type, put it here",
+    "severity": "High" or "Medium",
+    "confidence": integer 1-10 indicating certainty the bug is real and exploitable,
+    "description": "2-3 sentences: (1) the bug, (2) a concrete attacker-controlled exploit path naming the affected function, (3) impact"
+  }}
+]
+```"#;
+
+const DEFAULT_PROJECT_ANALYSIS: &str = r#"Analyze this smart contract project for CROSS-CONTRACT vulnerabilities that per-file analysis likely missed.
+
+## Project Overview:
+{project_summary}
+
+## In-scope Files:
+{scope_files}
+
+## Key Contract Source Code:
+{contract_sources}
+
+## Focus areas (cross-contract and architectural issues):
+- Cross-contract reentrancy and read-only reentrancy
+- Inconsistent access control across contracts (missing modifiers on setters, broken auth)
+- Token/ETH value flow issues spanning multiple contracts (fee distribution, reward accounting, stuck funds)
+- Price manipulation and oracle dependency issues
+- Front-running / MEV / sandwich attack vectors
+- Integer overflow/underflow (unsafe downcasts, mul-before-div precision loss)
+- Funds loss vectors (locked ether, arbitrary send, no withdrawal mechanism)
+- Logic errors in multi-contract workflows
+- DoS vectors in cross-contract calls
+
+## Classification rules:
+- Token/ETH flows (fees, rewards, balances, minting) -> "Token Handling"
+- Missing/broken access control -> "Access Control"
+- State after external call -> "Reentrancy"
+
+Classify by ROOT CAUSE using one of: {vuln_type_list}
+Only report HIGH or MEDIUM severity. ALWAYS specify which file each finding belongs to.
+
+```json
+[
+  {{
+    "file": "contracts/FileName.sol",
+    "vulnerability_type": "one of the types above",
+    "secondary_type": "optional alternate classification",
+    "severity": "High" or "Medium",
+    "description": "2-3 sentence explanation"
+  }}
+]
+```
+If no vulnerabilities found, output [].
+"#;
+
+const DEFAULT_CANDIDATE_VALIDATION: &str = r#"You have {n_candidates} unresolved vulnerability candidates that automated analysis (static analysis + IR traversal) flagged but could not confirm or deny. Symbolic execution was inconclusive for these.
+
+Validate each candidate against the source code. For each, determine if it's a REAL exploitable vulnerability or a false positive.
+
+## Unresolved Candidates:
+{candidates}
+
+## Contract Metadata (from IR):
+{ir_summary}
+
+## Static Analysis Flags (pre-computed, may be false positives):
+{sa_findings}
+
+## Symbolic Execution Insights:
+{symbolic_summary}
+
+## Source Code ({filepath}):
+```solidity
+{source}
+```
+
+## Vulnerability Categories:
+{vuln_types}
+
+For each candidate that IS a real vulnerability, include it in your output. Drop false positives.
+Also look for additional vulnerabilities the automated tools MISSED — especially:
+- Logic errors in business logic
+- Cross-function interaction bugs
+- Subtle token handling issues
+- Front-running / MEV vectors
+
+Output a JSON array. If no real vulnerabilities, output [].
+```json
+[
+  {{
+    "file": "{filepath}",
+    "vulnerability_type": "one of the categories above",
+    "severity": "High" or "Medium",
+    "confidence": integer 1-10,
+    "description": "2-3 sentences: bug, exploit path, impact"
+  }}
+]
+```"#;
+
+static SYSTEM_PROMPT: LazyLock<String> =
+    LazyLock::new(|| load_template("system.txt", DEFAULT_SYSTEM));
+static FILE_ANALYSIS_PROMPT: LazyLock<String> =
+    LazyLock::new(|| load_template("file_analysis.txt", DEFAULT_FILE_ANALYSIS));
+static PROJECT_ANALYSIS_PROMPT: LazyLock<String> =
+    LazyLock::new(|| load_template("project_analysis.txt", DEFAULT_PROJECT_ANALYSIS));
+static CANDIDATE_VALIDATION_PROMPT: LazyLock<String> =
+    LazyLock::new(|| load_template("candidate_validation.txt", DEFAULT_CANDIDATE_VALIDATION));
+
+static VULN_TYPE_LIST: LazyLock<String> = LazyLock::new(|| {
+    let common: Vec<String> = VULN_TYPES
+        .iter()
+        .filter(|vt| !RARE_TYPES.contains(vt))
+        .map(|vt| format!("- {vt}"))
+        .collect();
+    let rare: Vec<String> = VULN_TYPES
+        .iter()
+        .filter(|vt| RARE_TYPES.contains(vt))
+        .map(|vt| format!("- {vt}"))
+        .collect();
+    format!(
+        "{}\n\nRarely applicable (use only when clearly warranted):\n{}",
+        common.join("\n"),
+        rare.join("\n")
+    )
+});
+
+fn load_template(filename: &str, default: &str) -> String {
+    if let Ok(dir) = std::env::var("VULN_PROMPTS_DIR") {
+        let path = std::path::Path::new(&dir).join(filename);
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            return contents;
+        }
+    }
+    default.to_string()
+}
+
+fn render_template(template: &str, vars: &[(&str, &str)]) -> String {
+    let bytes = template.as_bytes();
+    let len = bytes.len();
+    let mut result = String::with_capacity(len);
+    let mut i = 0;
+    while i < len {
+        match bytes[i] {
+            b'{' if i + 1 < len && bytes[i + 1] == b'{' => {
+                result.push('{');
+                i += 2;
+            }
+            b'{' => {
+                if let Some(end) = bytes[i + 1..].iter().position(|&b| b == b'}') {
+                    let name = &template[i + 1..i + 1 + end];
+                    if let Some((_, val)) = vars.iter().find(|(k, _)| *k == name) {
+                        result.push_str(val);
+                    } else {
+                        result.push('{');
+                        result.push_str(name);
+                        result.push('}');
+                    }
+                    i += end + 2;
+                } else {
+                    result.push('{');
+                    i += 1;
+                }
+            }
+            b'}' if i + 1 < len && bytes[i + 1] == b'}' => {
+                result.push('}');
+                i += 2;
+            }
+            _ => {
+                let next = bytes[i..]
+                    .iter()
+                    .position(|&b| b == b'{' || b == b'}')
+                    .unwrap_or(len - i);
+                result.push_str(&template[i..i + next]);
+                i += next;
+            }
+        }
+    }
+    result
+}
+
+pub fn build_system_prompt() -> &'static str {
+    &SYSTEM_PROMPT
+}
+
+pub fn build_file_prompt(ctx: &FileContext) -> String {
+    let ir = if ctx.ir_summary.is_empty() {
+        "No IR data available."
+    } else {
+        &ctx.ir_summary
+    };
+    let symbolic = if ctx.symbolic_summary.is_empty() {
+        "No symbolic execution data available."
+    } else {
+        &ctx.symbolic_summary
+    };
+    let sa = format_sa_findings(&ctx.sa_findings);
+    render_template(
+        &FILE_ANALYSIS_PROMPT,
+        &[
+            ("vuln_types", &*VULN_TYPE_LIST),
+            ("ir_summary", ir),
+            ("sa_findings", &sa),
+            ("symbolic_summary", symbolic),
+            ("filepath", &ctx.filepath),
+            ("source", &ctx.source_code),
+        ],
+    )
+}
+
+pub fn build_project_prompt(ctx: &ContestContext) -> String {
+    let mut sorted_files: Vec<&FileContext> = ctx.files.iter().collect();
+    sorted_files.sort_by(|a, b| {
+        b.sa_findings
+            .len()
+            .cmp(&a.sa_findings.len())
+            .then_with(|| b.source_code.len().cmp(&a.source_code.len()))
+    });
+
+    let mut sources = Vec::new();
+    let mut total_chars = 0usize;
+    let limit = PROJECT_SOURCE_CHAR_LIMIT;
+    for fc in sorted_files {
+        if total_chars + fc.source_code.len() > limit && !sources.is_empty() {
+            break;
+        }
+        sources.push(format!(
+            "### {}\n```solidity\n{}\n```",
+            fc.filepath, fc.source_code
+        ));
+        total_chars += fc.source_code.len();
+    }
+
+    let contract_sources = if sources.is_empty() {
+        "Source code too large to include.".to_string()
+    } else {
+        sources.join("\n\n")
+    };
+
+    let scope = ctx
+        .scope_files
+        .iter()
+        .map(|f| format!("- {f}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let type_list = VULN_TYPES
+        .iter()
+        .map(|vt| vt.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    render_template(
+        &PROJECT_ANALYSIS_PROMPT,
+        &[
+            ("project_summary", &ctx.project_summary),
+            ("scope_files", &scope),
+            ("contract_sources", &contract_sources),
+            ("vuln_type_list", &type_list),
+        ],
+    )
+}
+
+pub fn build_file_prompt_with_candidates(ctx: &FileContext, candidates: &[Candidate]) -> String {
+    let ir = if ctx.ir_summary.is_empty() {
+        "No IR data available."
+    } else {
+        &ctx.ir_summary
+    };
+    let symbolic = if ctx.symbolic_summary.is_empty() {
+        "No symbolic execution data."
+    } else {
+        &ctx.symbolic_summary
+    };
+    let sa = format_sa_findings(&ctx.sa_findings);
+    let cands = format_candidates(candidates);
+    render_template(
+        &CANDIDATE_VALIDATION_PROMPT,
+        &[
+            ("n_candidates", &candidates.len().to_string()),
+            ("candidates", &cands),
+            ("ir_summary", ir),
+            ("sa_findings", &sa),
+            ("symbolic_summary", symbolic),
+            ("filepath", &ctx.filepath),
+            ("source", &ctx.source_code),
+            ("vuln_types", &*VULN_TYPE_LIST),
+        ],
+    )
+}
+
+pub fn format_sa_findings(findings: &[SAFinding]) -> String {
+    if findings.is_empty() {
+        return "No static analysis flags for this file.".to_string();
+    }
+    findings
+        .iter()
+        .map(|f| {
+            format!(
+                "- [{}] Line {}-{}: {}",
+                f.slug, f.start_line, f.end_line, f.description
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_candidates(candidates: &[Candidate]) -> String {
+    if candidates.is_empty() {
+        return "No unresolved candidates.".to_string();
+    }
+    candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            format!(
+                "{}. [{}] {} (lines {}-{}): {} [source: {}]",
+                i + 1,
+                c.vuln_type,
+                c.slug,
+                c.start_line,
+                c.end_line,
+                c.description,
+                c.source
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{SAFinding, VulnType};
+
+    #[test]
+    fn render_template_basic() {
+        assert_eq!(
+            render_template("hello {name}!", &[("name", "world")]),
+            "hello world!"
+        );
+    }
+
+    #[test]
+    fn render_template_escaped_braces() {
+        assert_eq!(
+            render_template("json: {{\"key\": \"{val}\"}}", &[("val", "x")]),
+            "json: {\"key\": \"x\"}"
+        );
+    }
+
+    #[test]
+    fn render_template_unknown_preserved() {
+        assert_eq!(
+            render_template("{known} {unknown}", &[("known", "yes")]),
+            "yes {unknown}"
+        );
+    }
+
+    #[test]
+    fn format_sa_findings_empty() {
+        assert_eq!(
+            format_sa_findings(&[]),
+            "No static analysis flags for this file."
+        );
+    }
+
+    #[test]
+    fn format_sa_findings_populated() {
+        let findings = vec![
+            SAFinding {
+                slug: "reentrancy".into(),
+                vuln_type: VulnType::Reentrancy,
+                filepath: "Vault.sol".into(),
+                start_line: 10,
+                end_line: 20,
+                description: "state after call".into(),
+                highlight: String::new(),
+            },
+            SAFinding {
+                slug: "locked-ether".into(),
+                vuln_type: VulnType::FundsLoss,
+                filepath: "Vault.sol".into(),
+                start_line: 30,
+                end_line: 35,
+                description: "no withdraw".into(),
+                highlight: String::new(),
+            },
+        ];
+        let result = format_sa_findings(&findings);
+        assert!(result.contains("- [reentrancy] Line 10-20: state after call"));
+        assert!(result.contains("- [locked-ether] Line 30-35: no withdraw"));
+    }
+
+    #[test]
+    fn format_candidates_empty() {
+        assert_eq!(format_candidates(&[]), "No unresolved candidates.");
+    }
+
+    #[test]
+    fn format_candidates_populated() {
+        let cands = vec![
+            Candidate {
+                filepath: "A.sol".into(),
+                vuln_type: VulnType::Reentrancy,
+                slug: "reentrancy".into(),
+                start_line: 5,
+                end_line: 15,
+                description: "cross-func".into(),
+                source: "sa_engine".into(),
+            },
+            Candidate {
+                filepath: "A.sol".into(),
+                vuln_type: VulnType::DoS,
+                slug: "unbounded-loop".into(),
+                start_line: 40,
+                end_line: 50,
+                description: "loop over array".into(),
+                source: "ir_engine".into(),
+            },
+        ];
+        let result = format_candidates(&cands);
+        assert!(result.starts_with("1. [Reentrancy]"));
+        assert!(result.contains("2. [DoS]"));
+        assert!(result.contains("[source: sa_engine]"));
+    }
+
+    #[test]
+    fn build_file_prompt_contains_expected() {
+        let ctx = FileContext {
+            filepath: "contracts/Test.sol".into(),
+            source_code: "pragma solidity ^0.8.0;".into(),
+            ir_summary: String::new(),
+            symbolic_summary: String::new(),
+            sa_findings: vec![SAFinding {
+                slug: "reentrancy".into(),
+                vuln_type: VulnType::Reentrancy,
+                filepath: "contracts/Test.sol".into(),
+                start_line: 1,
+                end_line: 5,
+                description: "test finding".into(),
+                highlight: String::new(),
+            }],
+        };
+        let prompt = build_file_prompt(&ctx);
+        assert!(prompt.contains("contracts/Test.sol"));
+        assert!(prompt.contains("pragma solidity ^0.8.0;"));
+        assert!(prompt.contains("[reentrancy] Line 1-5: test finding"));
+        assert!(prompt.contains("No IR data available."));
+        assert!(prompt.contains("No symbolic execution data available."));
+        // JSON braces unescaped from {{ → { and }} → }
+        assert!(prompt.contains("{\n    \"file\""));
+    }
+
+    #[test]
+    fn build_project_prompt_sorting_and_limit() {
+        let big_source = "x".repeat(50_000);
+        let small_source = "y".repeat(100);
+        let ctx = ContestContext {
+            contest_name: "test".into(),
+            project_summary: "A test project".into(),
+            scope_files: vec!["A.sol".into(), "B.sol".into()],
+            files: vec![
+                FileContext {
+                    filepath: "B.sol".into(),
+                    source_code: big_source,
+                    ir_summary: String::new(),
+                    symbolic_summary: String::new(),
+                    sa_findings: vec![],
+                },
+                FileContext {
+                    filepath: "A.sol".into(),
+                    source_code: small_source,
+                    ir_summary: String::new(),
+                    symbolic_summary: String::new(),
+                    sa_findings: vec![SAFinding {
+                        slug: "test".into(),
+                        vuln_type: VulnType::Other,
+                        filepath: "A.sol".into(),
+                        start_line: 1,
+                        end_line: 1,
+                        description: "d".into(),
+                        highlight: String::new(),
+                    }],
+                },
+            ],
+            direct_predictions: vec![],
+            llm_candidates: vec![],
+        };
+        let prompt = build_project_prompt(&ctx);
+        // SA-rich file (A.sol) appears before big empty file (B.sol)
+        let a_pos = prompt.find("### A.sol").unwrap();
+        let b_pos = prompt.find("### B.sol").unwrap();
+        assert!(a_pos < b_pos);
+        // 60k char limit: both fit (50k + 100 < 60k)
+        assert!(prompt.contains("### B.sol"));
+    }
+
+    #[test]
+    fn build_project_prompt_respects_60k_limit() {
+        let src_a = "a".repeat(40_000);
+        let src_b = "b".repeat(30_000);
+        let ctx = ContestContext {
+            contest_name: "test".into(),
+            project_summary: "proj".into(),
+            scope_files: vec!["A.sol".into(), "B.sol".into()],
+            files: vec![
+                FileContext {
+                    filepath: "A.sol".into(),
+                    source_code: src_a,
+                    ir_summary: String::new(),
+                    symbolic_summary: String::new(),
+                    sa_findings: vec![],
+                },
+                FileContext {
+                    filepath: "B.sol".into(),
+                    source_code: src_b,
+                    ir_summary: String::new(),
+                    symbolic_summary: String::new(),
+                    sa_findings: vec![],
+                },
+            ],
+            direct_predictions: vec![],
+            llm_candidates: vec![],
+        };
+        let prompt = build_project_prompt(&ctx);
+        // First file included, second excluded by 60k limit
+        assert!(prompt.contains("### A.sol"));
+        assert!(!prompt.contains("### B.sol"));
+    }
+
+    #[test]
+    fn build_file_prompt_with_candidates_output() {
+        let ctx = FileContext {
+            filepath: "V.sol".into(),
+            source_code: "code here".into(),
+            ir_summary: "has IR".into(),
+            symbolic_summary: String::new(),
+            sa_findings: vec![],
+        };
+        let cands = vec![Candidate {
+            filepath: "V.sol".into(),
+            vuln_type: VulnType::Reentrancy,
+            slug: "reent".into(),
+            start_line: 1,
+            end_line: 10,
+            description: "desc".into(),
+            source: "sa".into(),
+        }];
+        let prompt = build_file_prompt_with_candidates(&ctx, &cands);
+        assert!(prompt.contains("1 unresolved vulnerability candidates"));
+        assert!(prompt.contains("[Reentrancy] reent"));
+        assert!(prompt.contains("has IR"));
+        assert!(prompt.contains("No symbolic execution data."));
+    }
+
+    #[test]
+    fn vuln_type_list_structure() {
+        let list = &*VULN_TYPE_LIST;
+        assert!(list.contains("- Reentrancy"));
+        assert!(list.contains("- Access Control"));
+        assert!(list.contains("Rarely applicable (use only when clearly warranted):"));
+        assert!(list.contains("- State Management"));
+        assert!(list.contains("- Input Validation"));
+        assert!(list.contains("- Centralization Risk"));
+        // Rare types appear after the separator
+        let sep_pos = list.find("Rarely applicable").unwrap();
+        let state_pos = list.find("- State Management").unwrap();
+        assert!(state_pos > sep_pos);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,6 +265,18 @@ pub struct Candidate {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContestContext {
+    pub contest_name: String,
+    pub files: Vec<FileContext>,
+    pub project_summary: String,
+    pub scope_files: Vec<String>,
+    #[serde(default)]
+    pub direct_predictions: Vec<Prediction>,
+    #[serde(default)]
+    pub llm_candidates: Vec<Candidate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContestConfig {
     pub name: String,
     pub scope_files: Vec<String>,


### PR DESCRIPTION
Add prompts module with system, file analysis, project analysis, and candidate validation prompt templates. Includes render_template engine using byte-level scanning, LazyLock statics with VULN_PROMPTS_DIR override support, and ContestContext type. 12 tests covering template rendering, SA finding formatting, candidate formatting, prompt construction, sorting, and 60k char budget enforcement.