### PR TITLE
Add LLM client and wire full analysis orchestration pipeline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod engines;
+pub mod llm;
 pub mod loader;
 pub mod path_utils;
 pub mod postprocess;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+use tracing::{debug, warn};
+
+use crate::config;
+use crate::prompts;
+use crate::types::{Candidate, ContestContext, FileContext};
+
+const ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const RETRY_DELAYS_MS: &[u64] = &[500, 1000, 2000];
+
+pub struct LlmClient {
+    http: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+    semaphore: Arc<Semaphore>,
+}
+
+#[derive(Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    system: &'a str,
+    messages: Vec<ApiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct ApiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    content: Vec<ApiContentBlock>,
+}
+
+#[derive(Deserialize)]
+struct ApiContentBlock {
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorBody {
+    #[serde(default)]
+    error: Option<ApiErrorDetail>,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorDetail {
+    #[serde(default)]
+    message: String,
+}
+
+impl LlmClient {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: ANTHROPIC_BASE_URL.to_string(),
+            api_key,
+            model: config::MODEL.to_string(),
+            max_tokens: config::MAX_TOKENS_PER_RESPONSE,
+            semaphore: Arc::new(Semaphore::new(config::MAX_CONCURRENT_CALLS)),
+        }
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .context("ANTHROPIC_API_KEY not set in environment")?;
+        Ok(Self::new(api_key))
+    }
+
+    pub fn with_base_url(mut self, url: String) -> Self {
+        self.base_url = url;
+        self
+    }
+
+    async fn send(&self, system: &str, user_message: &str) -> Result<String> {
+        let _permit = self.semaphore.acquire().await.context("semaphore closed")?;
+
+        let url = format!("{}/v1/messages", self.base_url);
+        let body = ApiRequest {
+            model: &self.model,
+            max_tokens: self.max_tokens,
+            system,
+            messages: vec![ApiMessage {
+                role: "user",
+                content: user_message,
+            }],
+        };
+
+        let max_attempts = RETRY_DELAYS_MS.len() + 1;
+        let mut last_err = None;
+
+        for attempt in 0..max_attempts {
+            let resp = self
+                .http
+                .post(&url)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("content-type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .context("HTTP request failed")?;
+
+            let status = resp.status();
+
+            if status.is_success() {
+                let api_resp: ApiResponse =
+                    resp.json().await.context("failed to parse API response")?;
+                let text = api_resp
+                    .content
+                    .into_iter()
+                    .map(|b| b.text)
+                    .collect::<Vec<_>>()
+                    .join("");
+                return Ok(text);
+            }
+
+            let retryable = status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+            let resp_body = resp.text().await.unwrap_or_default();
+            let err_msg = serde_json::from_str::<ApiErrorBody>(&resp_body)
+                .ok()
+                .and_then(|b| b.error)
+                .map(|e| e.message)
+                .filter(|m| !m.is_empty())
+                .unwrap_or_else(|| format!("HTTP {status}"));
+
+            if !retryable {
+                bail!("API error ({}): {}", status, err_msg);
+            }
+
+            warn!(
+                attempt = attempt + 1,
+                status = %status,
+                "retryable API error, backing off"
+            );
+            last_err = Some(format!("API error ({}): {}", status, err_msg));
+
+            if let Some(&delay) = RETRY_DELAYS_MS.get(attempt) {
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+            }
+        }
+
+        bail!(
+            "exhausted {} retries: {}",
+            max_attempts,
+            last_err.unwrap_or_default()
+        )
+    }
+
+    pub async fn analyze_file(&self, ctx: &FileContext) -> Result<String> {
+        let system = prompts::build_system_prompt();
+        let user_msg = prompts::build_file_prompt(ctx);
+        debug!(filepath = %ctx.filepath, "analyzing file");
+        self.send(system, &user_msg).await
+    }
+
+    pub async fn analyze_file_with_candidates(
+        &self,
+        ctx: &FileContext,
+        candidates: &[Candidate],
+    ) -> Result<String> {
+        let system = prompts::build_system_prompt();
+        let user_msg = prompts::build_file_prompt_with_candidates(ctx, candidates);
+        debug!(filepath = %ctx.filepath, n_candidates = candidates.len(), "analyzing file with candidates");
+        self.send(system, &user_msg).await
+    }
+
+    pub async fn analyze_project(&self, ctx: &ContestContext) -> Result<String> {
+        let system = prompts::build_system_prompt();
+        let user_msg = prompts::build_project_prompt(ctx);
+        debug!(contest = %ctx.contest_name, "analyzing project");
+        self.send(system, &user_msg).await
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,20 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
 use clap::Parser;
+use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
+
+use vuln_analyzer::engines::sa_engine;
+use vuln_analyzer::llm::LlmClient;
+use vuln_analyzer::loader::context::build_file_context;
+use vuln_analyzer::loader::ir::build_project_summary;
+use vuln_analyzer::loader::sa::filter_static_analysis;
+use vuln_analyzer::loader::{list_contests, ContestLoader};
+use vuln_analyzer::postprocess::{deduplicate, parse_json_response, validate_finding};
+use vuln_analyzer::types::{ContestContext, Prediction};
 
 #[derive(Parser)]
 #[command(
@@ -10,18 +25,160 @@ struct Cli {
     #[arg(long, help = "Contest directory to analyze")]
     contest: Option<String>,
 
-    #[arg(long, help = "Run in batch mode")]
+    #[arg(long, help = "Run in batch mode over all contests")]
     batch: bool,
+
+    #[arg(
+        long,
+        default_value = "dataset/train",
+        help = "Dataset directory for batch mode"
+    )]
+    dataset: String,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenvy::dotenv().ok();
+
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
+    let client = Arc::new(LlmClient::from_env()?);
 
-    tracing::info!("vuln-analyzer starting");
+    if cli.batch {
+        let dataset_dir = PathBuf::from(&cli.dataset);
+        let contests = list_contests(&dataset_dir)?;
+        info!(count = contests.len(), "running batch mode");
+
+        for name in &contests {
+            let contest_path = dataset_dir.join("contracts").join(name);
+            match run_contest(&contest_path, &client).await {
+                Ok(preds) => {
+                    let json = serde_json::to_string_pretty(&preds)?;
+                    println!("{json}");
+                }
+                Err(e) => error!(contest = %name, error = %e, "contest failed"),
+            }
+        }
+    } else if let Some(ref contest) = cli.contest {
+        let contest_path = PathBuf::from(contest);
+        let preds = run_contest(&contest_path, &client).await?;
+        let json = serde_json::to_string_pretty(&preds)?;
+        println!("{json}");
+    } else {
+        anyhow::bail!("provide --contest <path> or --batch");
+    }
 
     Ok(())
+}
+
+async fn run_contest(contest_path: &Path, client: &Arc<LlmClient>) -> Result<Vec<Prediction>> {
+    let loader = ContestLoader::new(contest_path)?;
+    let contest_name = loader.contest_name().to_string();
+    info!(contest = %contest_name, "starting analysis");
+
+    let ir = loader.load_ir()?;
+    let sa = loader.load_static_analysis()?;
+    let sx = loader.load_symbolic_execution()?;
+    let scope = loader.list_source_files()?;
+
+    let sa_findings = filter_static_analysis(&sa, &scope);
+    let (engine_preds, candidates) = sa_engine::classify(&sa_findings, &contest_name);
+
+    let mut candidate_map: HashMap<String, Vec<_>> = HashMap::new();
+    for c in &candidates {
+        candidate_map
+            .entry(c.filepath.clone())
+            .or_default()
+            .push(c.clone());
+    }
+
+    let mut file_contexts = Vec::new();
+    for filepath in &scope {
+        let source = loader
+            .get_source(filepath)
+            .with_context(|| format!("reading source for {filepath}"))?;
+        let ctx = build_file_context(filepath, &source, &ir, sx.as_ref(), &sa_findings);
+        file_contexts.push(ctx);
+    }
+
+    let mut handles = Vec::new();
+    for ctx in &file_contexts {
+        let client = Arc::clone(client);
+        let ctx = ctx.clone();
+        let file_candidates = candidate_map.remove(&ctx.filepath).unwrap_or_default();
+        let contest = contest_name.clone();
+
+        handles.push(tokio::spawn(async move {
+            let raw_text = if file_candidates.is_empty() {
+                client.analyze_file(&ctx).await
+            } else {
+                client
+                    .analyze_file_with_candidates(&ctx, &file_candidates)
+                    .await
+            };
+
+            match raw_text {
+                Ok(text) => {
+                    let parsed = parse_json_response(&text);
+                    let preds: Vec<Prediction> = parsed
+                        .iter()
+                        .filter_map(|v| validate_finding(v, &contest, &ctx.filepath))
+                        .collect();
+                    preds
+                }
+                Err(e) => {
+                    error!(file = %ctx.filepath, error = %e, "file analysis failed");
+                    vec![]
+                }
+            }
+        }));
+    }
+
+    let mut all_preds = engine_preds.clone();
+    let mut file_failures = 0usize;
+    for handle in handles {
+        match handle.await {
+            Ok(preds) => all_preds.extend(preds),
+            Err(e) => {
+                file_failures += 1;
+                error!(error = %e, "task join failed");
+            }
+        }
+    }
+    if file_failures > 0 {
+        info!(
+            failed = file_failures,
+            total = scope.len(),
+            "file analyses had failures"
+        );
+    }
+
+    let project_summary = build_project_summary(&ir, &sa_findings, &scope);
+    let project_ctx = ContestContext {
+        contest_name: contest_name.clone(),
+        files: file_contexts,
+        project_summary,
+        scope_files: scope,
+        direct_predictions: engine_preds,
+        llm_candidates: candidates,
+    };
+
+    match client.analyze_project(&project_ctx).await {
+        Ok(text) => {
+            let parsed = parse_json_response(&text);
+            let project_preds: Vec<Prediction> = parsed
+                .iter()
+                .filter_map(|v| validate_finding(v, &contest_name, "project-level"))
+                .collect();
+            all_preds.extend(project_preds);
+        }
+        Err(e) => error!(error = %e, "project analysis failed"),
+    }
+
+    let deduped = deduplicate(all_preds);
+    info!(contest = %contest_name, findings = deduped.len(), "analysis complete");
+    Ok(deduped)
 }

--- a/tests/llm_integration.rs
+++ b/tests/llm_integration.rs
@@ -1,0 +1,142 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+async fn mock_server(
+    listener: TcpListener,
+    handler: impl Fn(usize) -> (u16, String) + Send + Sync + 'static,
+) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    loop {
+        let Ok((stream, _)) = listener.accept().await else {
+            break;
+        };
+        let n = counter.fetch_add(1, Ordering::SeqCst);
+        let (status, body) = handler(n);
+
+        let (reader, mut writer) = tokio::io::split(stream);
+        let mut buf_reader = BufReader::new(reader);
+
+        let mut content_length: usize = 0;
+        loop {
+            let mut line = String::new();
+            if buf_reader.read_line(&mut line).await.unwrap_or(0) == 0 {
+                break;
+            }
+            if let Some(val) = line
+                .strip_prefix("content-length:")
+                .or_else(|| line.strip_prefix("Content-Length:"))
+            {
+                content_length = val.trim().parse().unwrap_or(0);
+            }
+            if line == "\r\n" {
+                break;
+            }
+        }
+
+        if content_length > 0 {
+            let mut body_buf = vec![0u8; content_length];
+            let _ = tokio::io::AsyncReadExt::read_exact(&mut buf_reader, &mut body_buf).await;
+        }
+
+        let status_text = match status {
+            200 => "OK",
+            400 => "Bad Request",
+            429 => "Too Many Requests",
+            500 => "Internal Server Error",
+            _ => "Error",
+        };
+
+        let resp = format!(
+            "HTTP/1.1 {status} {status_text}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len(),
+        );
+        let _ = writer.write_all(resp.as_bytes()).await;
+        let _ = writer.shutdown().await;
+    }
+}
+
+fn valid_response() -> String {
+    r#"{"content":[{"type":"text","text":"[{\"file\":\"test.sol\",\"vulnerability_type\":\"Reentrancy\",\"severity\":\"High\",\"confidence\":8,\"description\":\"State change after call\"}]"}]}"#.to_string()
+}
+
+fn make_client(port: u16) -> vuln_analyzer::llm::LlmClient {
+    vuln_analyzer::llm::LlmClient::new("test-key".into())
+        .with_base_url(format!("http://127.0.0.1:{port}"))
+}
+
+fn make_file_context() -> vuln_analyzer::types::FileContext {
+    vuln_analyzer::types::FileContext {
+        filepath: "test.sol".into(),
+        source_code: "pragma solidity ^0.8.0;".into(),
+        ir_summary: String::new(),
+        symbolic_summary: String::new(),
+        sa_findings: vec![],
+    }
+}
+
+#[tokio::test]
+async fn analyze_file_returns_parsed_text() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(mock_server(listener, |_| (200, valid_response())));
+
+    let client = make_client(port);
+    let ctx = make_file_context();
+    let result = client.analyze_file(&ctx).await.unwrap();
+
+    assert!(result.contains("Reentrancy"));
+    assert!(result.contains("State change after call"));
+}
+
+#[tokio::test]
+async fn retry_on_server_error() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&call_count);
+
+    tokio::spawn(mock_server(listener, move |n| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        if n < 2 {
+            (500, r#"{"error":{"message":"server error"}}"#.to_string())
+        } else {
+            (200, valid_response())
+        }
+    }));
+
+    let client = make_client(port);
+    let ctx = make_file_context();
+    let result = client.analyze_file(&ctx).await.unwrap();
+
+    assert!(result.contains("Reentrancy"));
+    assert!(call_count.load(Ordering::SeqCst) >= 3);
+}
+
+#[tokio::test]
+async fn non_retryable_error_fails_immediately() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&call_count);
+
+    tokio::spawn(mock_server(listener, move |_| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        (
+            400,
+            r#"{"error":{"message":"invalid request"}}"#.to_string(),
+        )
+    }));
+
+    let client = make_client(port);
+    let ctx = make_file_context();
+    let err = client.analyze_file(&ctx).await.unwrap_err();
+
+    assert!(err.to_string().contains("400"));
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
Introduce async LlmClient with retry logic and concurrency limits for the Anthropic API. Wire main.rs into a complete pipeline: load contest data, run static analysis engine, fan out per-file LLM analysis, aggregate with project-level pass, then deduplicate. Add integration tests with mock TCP server for LLM client.