### PR TITLE
Wire IR and symbolic engines into pipeline with full CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +220,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -303,6 +322,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -628,6 +659,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +813,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -918,6 +968,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1469,6 +1525,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -1592,6 +1649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1709,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenvy",
+ "indicatif",
  "petgraph",
  "phf",
  "pretty_assertions",
@@ -1655,6 +1719,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1792,6 +1857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1906,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 phf = { version = "0.11", features = ["macros"] }
 petgraph = "0.7"
 strum = { version = "0.27", features = ["derive"] }
+indicatif = "0.17"
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod engines;
 pub mod llm;
 pub mod loader;
 pub mod path_utils;
+pub mod pipeline;
 pub mod postprocess;
 pub mod prompts;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,15 @@
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use tracing::{error, info};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-use vuln_analyzer::engines::sa_engine;
 use vuln_analyzer::llm::LlmClient;
-use vuln_analyzer::loader::context::build_file_context;
-use vuln_analyzer::loader::ir::build_project_summary;
-use vuln_analyzer::loader::sa::filter_static_analysis;
-use vuln_analyzer::loader::{list_contests, ContestLoader};
-use vuln_analyzer::postprocess::{deduplicate, parse_json_response, validate_finding};
-use vuln_analyzer::types::{ContestContext, Prediction};
+use vuln_analyzer::pipeline::{self, PipelineConfig};
 
 #[derive(Parser)]
 #[command(
@@ -34,151 +29,86 @@ struct Cli {
         help = "Dataset directory for batch mode"
     )]
     dataset: String,
+
+    #[arg(long, help = "Stages 1-3 only, skip LLM calls")]
+    dry_run: bool,
+
+    #[arg(long, help = "DEBUG-level tracing, disables progress bars")]
+    verbose: bool,
+
+    #[arg(long, help = "Write per-contest predictions to this directory")]
+    output_dir: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
-
     let cli = Cli::parse();
-    let client = Arc::new(LlmClient::from_env()?);
+
+    let filter = if cli.verbose {
+        EnvFilter::new("debug")
+    } else {
+        EnvFilter::from_default_env()
+    };
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    let cancel = CancellationToken::new();
+    let cancel_hook = cancel.clone();
+    tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            info!("received Ctrl+C, shutting down gracefully");
+            cancel_hook.cancel();
+        }
+    });
+
+    let config = PipelineConfig {
+        dry_run: cli.dry_run,
+        verbose: cli.verbose,
+        output_dir: cli.output_dir.map(PathBuf::from),
+        batch_concurrency: 4,
+    };
+
+    let start = Instant::now();
+
+    let client = if cli.dry_run {
+        Arc::new(LlmClient::new("dry-run".into()))
+    } else {
+        Arc::new(LlmClient::from_env()?)
+    };
 
     if cli.batch {
         let dataset_dir = PathBuf::from(&cli.dataset);
-        let contests = list_contests(&dataset_dir)?;
-        info!(count = contests.len(), "running batch mode");
-
-        for name in &contests {
-            let contest_path = dataset_dir.join("contracts").join(name);
-            match run_contest(&contest_path, &client).await {
-                Ok(preds) => {
-                    let json = serde_json::to_string_pretty(&preds)?;
-                    println!("{json}");
-                }
-                Err(e) => error!(contest = %name, error = %e, "contest failed"),
-            }
-        }
+        let results = pipeline::run_batch(&dataset_dir, &client, &config, &cancel).await?;
+        pipeline::write_output(&results, config.output_dir.as_deref())?;
+        print_batch_summary(&results, start.elapsed());
     } else if let Some(ref contest) = cli.contest {
         let contest_path = PathBuf::from(contest);
-        let preds = run_contest(&contest_path, &client).await?;
-        let json = serde_json::to_string_pretty(&preds)?;
-        println!("{json}");
+        let result = pipeline::run_contest(&contest_path, &client, &config, &cancel, None).await?;
+        pipeline::write_output(&[result], config.output_dir.as_deref())?;
     } else {
         anyhow::bail!("provide --contest <path> or --batch");
     }
 
+    info!(elapsed = ?start.elapsed(), "total runtime");
     Ok(())
 }
 
-async fn run_contest(contest_path: &Path, client: &Arc<LlmClient>) -> Result<Vec<Prediction>> {
-    let loader = ContestLoader::new(contest_path)?;
-    let contest_name = loader.contest_name().to_string();
-    info!(contest = %contest_name, "starting analysis");
+fn print_batch_summary(results: &[pipeline::ContestResult], elapsed: std::time::Duration) {
+    let total_findings: usize = results.iter().map(|r| r.predictions.len()).sum();
+    let total_sa: usize = results.iter().map(|r| r.stats.sa_preds).sum();
+    let total_ir: usize = results.iter().map(|r| r.stats.ir_preds).sum();
+    let total_sym_confirmed: usize = results.iter().map(|r| r.stats.symbolic_confirmed).sum();
+    let total_sym_killed: usize = results.iter().map(|r| r.stats.symbolic_killed).sum();
+    let total_llm: usize = results.iter().map(|r| r.stats.llm_preds).sum();
 
-    let ir = loader.load_ir()?;
-    let sa = loader.load_static_analysis()?;
-    let sx = loader.load_symbolic_execution()?;
-    let scope = loader.list_source_files()?;
-
-    let sa_findings = filter_static_analysis(&sa, &scope);
-    let (engine_preds, candidates) = sa_engine::classify(&sa_findings, &contest_name);
-
-    let mut candidate_map: HashMap<String, Vec<_>> = HashMap::new();
-    for c in &candidates {
-        candidate_map
-            .entry(c.filepath.clone())
-            .or_default()
-            .push(c.clone());
-    }
-
-    let mut file_contexts = Vec::new();
-    for filepath in &scope {
-        let source = loader
-            .get_source(filepath)
-            .with_context(|| format!("reading source for {filepath}"))?;
-        let ctx = build_file_context(filepath, &source, &ir, sx.as_ref(), &sa_findings);
-        file_contexts.push(ctx);
-    }
-
-    let mut handles = Vec::new();
-    for ctx in &file_contexts {
-        let client = Arc::clone(client);
-        let ctx = ctx.clone();
-        let file_candidates = candidate_map.remove(&ctx.filepath).unwrap_or_default();
-        let contest = contest_name.clone();
-
-        handles.push(tokio::spawn(async move {
-            let raw_text = if file_candidates.is_empty() {
-                client.analyze_file(&ctx).await
-            } else {
-                client
-                    .analyze_file_with_candidates(&ctx, &file_candidates)
-                    .await
-            };
-
-            match raw_text {
-                Ok(text) => {
-                    let parsed = parse_json_response(&text);
-                    let preds: Vec<Prediction> = parsed
-                        .iter()
-                        .filter_map(|v| validate_finding(v, &contest, &ctx.filepath))
-                        .collect();
-                    preds
-                }
-                Err(e) => {
-                    error!(file = %ctx.filepath, error = %e, "file analysis failed");
-                    vec![]
-                }
-            }
-        }));
-    }
-
-    let mut all_preds = engine_preds.clone();
-    let mut file_failures = 0usize;
-    for handle in handles {
-        match handle.await {
-            Ok(preds) => all_preds.extend(preds),
-            Err(e) => {
-                file_failures += 1;
-                error!(error = %e, "task join failed");
-            }
-        }
-    }
-    if file_failures > 0 {
-        info!(
-            failed = file_failures,
-            total = scope.len(),
-            "file analyses had failures"
-        );
-    }
-
-    let project_summary = build_project_summary(&ir, &sa_findings, &scope);
-    let project_ctx = ContestContext {
-        contest_name: contest_name.clone(),
-        files: file_contexts,
-        project_summary,
-        scope_files: scope,
-        direct_predictions: engine_preds,
-        llm_candidates: candidates,
-    };
-
-    match client.analyze_project(&project_ctx).await {
-        Ok(text) => {
-            let parsed = parse_json_response(&text);
-            let project_preds: Vec<Prediction> = parsed
-                .iter()
-                .filter_map(|v| validate_finding(v, &contest_name, "project-level"))
-                .collect();
-            all_preds.extend(project_preds);
-        }
-        Err(e) => error!(error = %e, "project analysis failed"),
-    }
-
-    let deduped = deduplicate(all_preds);
-    info!(contest = %contest_name, findings = deduped.len(), "analysis complete");
-    Ok(deduped)
+    eprintln!("\n--- Batch Summary ---");
+    eprintln!("Contests:           {}", results.len());
+    eprintln!("Total findings:     {total_findings}");
+    eprintln!("  SA engine:        {total_sa}");
+    eprintln!("  IR engine:        {total_ir}");
+    eprintln!("  Symbolic confirmed: {total_sym_confirmed}");
+    eprintln!("  Symbolic killed:  {total_sym_killed}");
+    eprintln!("  LLM:              {total_llm}");
+    eprintln!("Elapsed:            {:.1}s", elapsed.as_secs_f64());
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,349 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info};
+
+use crate::engines::{ir_engine, sa_engine, symbolic_engine};
+use crate::llm::LlmClient;
+use crate::loader::context::build_file_context;
+use crate::loader::ir::build_project_summary;
+use crate::loader::sa::filter_static_analysis;
+use crate::loader::{list_contests, ContestLoader};
+use crate::postprocess::{deduplicate, parse_json_response, validate_finding};
+use crate::types::{ContestContext, EngineOutput, Prediction};
+
+const MAX_FILE_LLM_CONCURRENCY: usize = 16;
+
+#[derive(Debug, Clone)]
+pub struct PipelineConfig {
+    pub dry_run: bool,
+    pub verbose: bool,
+    pub output_dir: Option<PathBuf>,
+    pub batch_concurrency: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PipelineStats {
+    pub sa_preds: usize,
+    pub ir_preds: usize,
+    pub symbolic_confirmed: usize,
+    pub symbolic_killed: usize,
+    pub llm_preds: usize,
+}
+
+#[derive(Debug)]
+pub struct ContestResult {
+    pub contest_name: String,
+    pub predictions: Vec<Prediction>,
+    pub elapsed: std::time::Duration,
+    pub stats: PipelineStats,
+}
+
+pub async fn run_contest(
+    contest_path: &Path,
+    client: &Arc<LlmClient>,
+    config: &PipelineConfig,
+    cancel: &CancellationToken,
+    progress: Option<&ProgressBar>,
+) -> Result<ContestResult> {
+    let start = Instant::now();
+    let loader = ContestLoader::new(contest_path)?;
+    let contest_name = loader.contest_name().to_string();
+    let mut stats = PipelineStats::default();
+
+    info!(contest = %contest_name, "starting analysis");
+    set_message(progress, "loading data");
+
+    let ir = loader.load_ir()?;
+    let sa = loader.load_static_analysis()?;
+    let sx = loader.load_symbolic_execution()?;
+    let scope = loader.list_source_files()?;
+
+    if cancel.is_cancelled() {
+        anyhow::bail!("cancelled");
+    }
+
+    // Stage 1: Static analysis classification
+    set_message(progress, "SA classify");
+    let sa_findings = filter_static_analysis(&sa, &scope);
+    let (sa_preds, sa_candidates) = sa_engine::classify(&sa_findings, &contest_name);
+    stats.sa_preds = sa_preds.len();
+    debug!(contest = %contest_name, preds = sa_preds.len(), candidates = sa_candidates.len(), "SA engine done");
+
+    // Stage 2: IR engine analysis
+    set_message(progress, "IR analyze");
+    let ir_output = ir_engine::analyze(&ir, &contest_name, &scope);
+    stats.ir_preds = ir_output.predictions.len();
+    debug!(contest = %contest_name, preds = ir_output.predictions.len(), candidates = ir_output.candidates.len(), "IR engine done");
+
+    // Merge SA + IR outputs
+    let mut merged = EngineOutput {
+        predictions: sa_preds,
+        candidates: sa_candidates,
+    };
+    merged.merge(ir_output);
+
+    // Stage 3: Symbolic verification
+    set_message(progress, "symbolic verify");
+    if let Some(ref sx_data) = sx {
+        let verification = symbolic_engine::verify(sx_data, &merged.candidates, &contest_name);
+        stats.symbolic_confirmed = verification.confirmed.len();
+        stats.symbolic_killed = verification.killed.len();
+        debug!(
+            contest = %contest_name,
+            confirmed = verification.confirmed.len(),
+            killed = verification.killed.len(),
+            inconclusive = verification.inconclusive.len(),
+            "symbolic verification done"
+        );
+
+        merged.predictions.extend(verification.confirmed);
+        // Replace candidates with only inconclusive ones (killed are dropped)
+        merged.candidates = verification.inconclusive;
+    }
+
+    if cancel.is_cancelled() {
+        anyhow::bail!("cancelled");
+    }
+
+    // Stage 4: LLM analysis (skip if dry-run)
+    if config.dry_run {
+        info!(contest = %contest_name, "dry-run: skipping LLM stages");
+        let deduped = deduplicate(merged.predictions);
+        return Ok(ContestResult {
+            contest_name,
+            predictions: deduped,
+            elapsed: start.elapsed(),
+            stats,
+        });
+    }
+
+    set_message(progress, "LLM file analysis");
+
+    let mut candidate_map: HashMap<String, Vec<_>> = HashMap::new();
+    for c in &merged.candidates {
+        candidate_map
+            .entry(c.filepath.clone())
+            .or_default()
+            .push(c.clone());
+    }
+
+    let mut file_contexts = Vec::new();
+    for filepath in &scope {
+        let source = loader
+            .get_source(filepath)
+            .with_context(|| format!("reading source for {filepath}"))?;
+        let ctx = build_file_context(filepath, &source, &ir, sx.as_ref(), &sa_findings);
+        file_contexts.push(ctx);
+    }
+
+    let file_llm_sem = Arc::new(Semaphore::new(MAX_FILE_LLM_CONCURRENCY));
+    let mut handles = Vec::new();
+    for ctx in &file_contexts {
+        if cancel.is_cancelled() {
+            break;
+        }
+        let client = Arc::clone(client);
+        let sem = Arc::clone(&file_llm_sem);
+        let ctx = ctx.clone();
+        let file_candidates = candidate_map
+            .get(&ctx.filepath)
+            .cloned()
+            .unwrap_or_default();
+        let contest = contest_name.clone();
+        let token = cancel.clone();
+
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await;
+            tokio::select! {
+                _ = token.cancelled() => vec![],
+                result = async {
+                    let raw_text = if file_candidates.is_empty() {
+                        client.analyze_file(&ctx).await
+                    } else {
+                        client.analyze_file_with_candidates(&ctx, &file_candidates).await
+                    };
+                    match raw_text {
+                        Ok(text) => {
+                            let parsed = parse_json_response(&text);
+                            parsed
+                                .iter()
+                                .filter_map(|v| validate_finding(v, &contest, &ctx.filepath))
+                                .collect()
+                        }
+                        Err(e) => {
+                            error!(file = %ctx.filepath, error = %e, "file analysis failed");
+                            vec![]
+                        }
+                    }
+                } => result,
+            }
+        }));
+    }
+
+    let mut all_preds = merged.predictions;
+    let mut llm_count = 0usize;
+    for handle in handles {
+        match handle.await {
+            Ok(preds) => {
+                llm_count += preds.len();
+                all_preds.extend(preds);
+            }
+            Err(e) => error!(error = %e, "task join failed"),
+        }
+    }
+
+    if cancel.is_cancelled() {
+        anyhow::bail!("cancelled");
+    }
+
+    // Stage 5: Project-level LLM
+    set_message(progress, "LLM project analysis");
+    let project_summary = build_project_summary(&ir, &sa_findings, &scope);
+    let project_ctx = ContestContext {
+        contest_name: contest_name.clone(),
+        files: file_contexts,
+        project_summary,
+        scope_files: scope,
+        direct_predictions: all_preds
+            .iter()
+            .filter(|p| !p.source.is_empty())
+            .cloned()
+            .collect(),
+        llm_candidates: merged.candidates,
+    };
+
+    match client.analyze_project(&project_ctx).await {
+        Ok(text) => {
+            let parsed = parse_json_response(&text);
+            let project_preds: Vec<Prediction> = parsed
+                .iter()
+                .filter_map(|v| validate_finding(v, &contest_name, "project-level"))
+                .collect();
+            llm_count += project_preds.len();
+            all_preds.extend(project_preds);
+        }
+        Err(e) => error!(error = %e, "project analysis failed"),
+    }
+
+    stats.llm_preds = llm_count;
+    let deduped = deduplicate(all_preds);
+    info!(contest = %contest_name, findings = deduped.len(), "analysis complete");
+
+    Ok(ContestResult {
+        contest_name,
+        predictions: deduped,
+        elapsed: start.elapsed(),
+        stats,
+    })
+}
+
+pub async fn run_batch(
+    dataset_dir: &Path,
+    client: &Arc<LlmClient>,
+    config: &PipelineConfig,
+    cancel: &CancellationToken,
+) -> Result<Vec<ContestResult>> {
+    let contests = list_contests(dataset_dir)?;
+    if contests.is_empty() {
+        anyhow::bail!("no contests found in {}", dataset_dir.display());
+    }
+    info!(count = contests.len(), "running batch mode");
+
+    let semaphore = Arc::new(Semaphore::new(config.batch_concurrency));
+    let mp = if config.verbose {
+        None
+    } else {
+        Some(MultiProgress::new())
+    };
+
+    let spinner_style = ProgressStyle::with_template("{spinner:.cyan} {prefix}: {msg}")
+        .unwrap()
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
+
+    let mut join_set = JoinSet::new();
+
+    for name in contests {
+        let contest_path = dataset_dir.join("contracts").join(&name);
+        let client = Arc::clone(client);
+        let cfg = config.clone();
+        let token = cancel.clone();
+        let sem = Arc::clone(&semaphore);
+
+        let pb = mp.as_ref().map(|m| {
+            let bar = m.add(ProgressBar::new_spinner());
+            bar.set_style(spinner_style.clone());
+            bar.set_prefix(name.clone());
+            bar.set_message("waiting");
+            bar.enable_steady_tick(std::time::Duration::from_millis(120));
+            bar
+        });
+
+        join_set.spawn(async move {
+            let _permit = sem.acquire_owned().await;
+            if let Some(ref bar) = pb {
+                bar.set_message("running");
+            }
+            let result = run_contest(&contest_path, &client, &cfg, &token, pb.as_ref()).await;
+            if let Some(bar) = pb {
+                match &result {
+                    Ok(r) => bar.finish_with_message(format!(
+                        "done ({} findings, {:.1}s)",
+                        r.predictions.len(),
+                        r.elapsed.as_secs_f64()
+                    )),
+                    Err(e) => bar.finish_with_message(format!("error: {e}")),
+                }
+            }
+            result
+        });
+    }
+
+    let mut results = Vec::new();
+    while let Some(outcome) = join_set.join_next().await {
+        match outcome {
+            Ok(Ok(result)) => results.push(result),
+            Ok(Err(e)) => error!(error = %e, "contest failed"),
+            Err(e) => error!(error = %e, "task panicked"),
+        }
+    }
+
+    results.sort_by(|a, b| a.contest_name.cmp(&b.contest_name));
+    Ok(results)
+}
+
+pub fn write_output(results: &[ContestResult], output_dir: Option<&Path>) -> Result<()> {
+    match output_dir {
+        Some(dir) => {
+            for result in results {
+                let contest_dir = dir.join(&result.contest_name);
+                std::fs::create_dir_all(&contest_dir)
+                    .with_context(|| format!("creating {}", contest_dir.display()))?;
+                let path = contest_dir.join("predictions.json");
+                let json = serde_json::to_string_pretty(&result.predictions)?;
+                std::fs::write(&path, &json)
+                    .with_context(|| format!("writing {}", path.display()))?;
+                info!(path = %path.display(), count = result.predictions.len(), "wrote predictions");
+            }
+        }
+        None => {
+            let all_preds: Vec<&Prediction> = results.iter().flat_map(|r| &r.predictions).collect();
+            let json = serde_json::to_string_pretty(&all_preds)?;
+            println!("{json}");
+        }
+    }
+    Ok(())
+}
+
+fn set_message(progress: Option<&ProgressBar>, msg: &str) {
+    if let Some(pb) = progress {
+        pb.set_message(msg.to_string());
+    }
+}


### PR DESCRIPTION
Extract orchestration from main.rs into pipeline.rs with a 5-stage flow: SA classify, IR analyze, merge, symbolic verify, then LLM. Symbolic verification confirms/kills candidates before sending inconclusive ones to LLM, reducing unnecessary API calls.

Add --dry-run (skip LLM), --verbose (debug tracing), and --output-dir (per-contest JSON files). Batch mode runs contests concurrently via JoinSet + Semaphore with progress spinners. Ctrl+C triggers graceful shutdown through CancellationToken.