### PR TITLE
Add structured error handling, tracing spans, and CLI log controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,12 +1658,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1718,6 +1751,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ regex = "1"
 dotenvy = "0.15"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+thiserror = "2"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 phf = { version = "0.11", features = ["macros"] }
 petgraph = "0.7"
 strum = { version = "0.27", features = ["derive"] }

--- a/src/engines/ir_engine.rs
+++ b/src/engines/ir_engine.rs
@@ -484,6 +484,7 @@ fn build_contract_index(ir: &RawIr) -> HashMap<String, &RawIrContract> {
     index
 }
 
+#[tracing::instrument(name = "ir_engine", skip_all, fields(contest = %contest_name))]
 pub fn analyze(ir: &RawIr, contest_name: &str, scope_files: &[String]) -> EngineOutput {
     let mut output = EngineOutput::default();
     let contract_index = build_contract_index(ir);

--- a/src/engines/sa_engine.rs
+++ b/src/engines/sa_engine.rs
@@ -20,6 +20,7 @@ fn build_description(finding: &SAFinding) -> String {
     desc
 }
 
+#[tracing::instrument(name = "sa_engine", skip_all, fields(contest = %contest_name, findings = sa_findings.len()))]
 pub fn classify(
     sa_findings: &[SAFinding],
     contest_name: &str,

--- a/src/engines/symbolic_engine.rs
+++ b/src/engines/symbolic_engine.rs
@@ -117,6 +117,7 @@ fn severity_for_type(vuln_type: VulnType) -> Severity {
     }
 }
 
+#[tracing::instrument(name = "symbolic_engine", skip_all, fields(contest = %contest_name, candidates = candidates.len()))]
 pub fn verify(
     sx: &RawSymbolicExecution,
     candidates: &[Candidate],

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,4 +73,3 @@ pub enum AnalysisError {
     #[error("provide --contest <path> or --batch")]
     MissingCommand,
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    #[error("contest directory not found: {path}")]
+    ContestNotFound { path: PathBuf },
+
+    #[error("contest_path has no directory name")]
+    InvalidContestPath,
+
+    #[error("contest_path must be at least 2 levels deep: {path}")]
+    ShallowContestPath { path: PathBuf },
+
+    #[error("analysis file not found: {path}")]
+    AnalysisFileNotFound { path: PathBuf },
+
+    #[error("I/O error on {path}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("parse error on {path}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LlmError {
+    #[error("ANTHROPIC_API_KEY not set in environment")]
+    MissingApiKey,
+
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+
+    #[error("API error ({status}): {message}")]
+    ApiError { status: u16, message: String },
+
+    #[error("exhausted {attempts} retries: {last_error}")]
+    RetriesExhausted { attempts: usize, last_error: String },
+
+    #[error("failed to parse API response: {0}")]
+    ResponseParse(String),
+
+    #[error("semaphore closed")]
+    SemaphoreClosed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnalysisError {
+    #[error("cancelled")]
+    Cancelled,
+
+    #[error("no contests found in {path}")]
+    NoContests { path: PathBuf },
+
+    #[error(transparent)]
+    Load(#[from] LoadError),
+
+    #[error(transparent)]
+    Llm(#[from] LlmError),
+
+    #[error("output write failed")]
+    OutputWrite(#[source] std::io::Error),
+
+    #[error(transparent)]
+    Serialize(#[from] serde_json::Error),
+
+    #[error("provide --contest <path> or --batch")]
+    MissingCommand,
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod engines;
+pub mod error;
 pub mod llm;
 pub mod loader;
 pub mod path_utils;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::config;
+use crate::error::LlmError;
 use crate::prompts;
 use crate::types::{Candidate, ContestContext, FileContext};
 
@@ -72,9 +72,8 @@ impl LlmClient {
         }
     }
 
-    pub fn from_env() -> Result<Self> {
-        let api_key = std::env::var("ANTHROPIC_API_KEY")
-            .context("ANTHROPIC_API_KEY not set in environment")?;
+    pub fn from_env() -> Result<Self, LlmError> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| LlmError::MissingApiKey)?;
         Ok(Self::new(api_key))
     }
 
@@ -83,8 +82,13 @@ impl LlmClient {
         self
     }
 
-    async fn send(&self, system: &str, user_message: &str) -> Result<String> {
-        let _permit = self.semaphore.acquire().await.context("semaphore closed")?;
+    #[tracing::instrument(name = "llm_send", skip_all, level = "debug")]
+    async fn send(&self, system: &str, user_message: &str) -> Result<String, LlmError> {
+        let _permit = self
+            .semaphore
+            .acquire()
+            .await
+            .map_err(|_| LlmError::SemaphoreClosed)?;
 
         let url = format!("{}/v1/messages", self.base_url);
         let body = ApiRequest {
@@ -96,6 +100,8 @@ impl LlmClient {
                 content: user_message,
             }],
         };
+
+        trace!(request_len = user_message.len(), "sending LLM request");
 
         let max_attempts = RETRY_DELAYS_MS.len() + 1;
         let mut last_err = None;
@@ -109,20 +115,22 @@ impl LlmClient {
                 .header("content-type", "application/json")
                 .json(&body)
                 .send()
-                .await
-                .context("HTTP request failed")?;
+                .await?;
 
             let status = resp.status();
 
             if status.is_success() {
-                let api_resp: ApiResponse =
-                    resp.json().await.context("failed to parse API response")?;
+                let api_resp: ApiResponse = resp
+                    .json()
+                    .await
+                    .map_err(|e| LlmError::ResponseParse(e.to_string()))?;
                 let text = api_resp
                     .content
                     .into_iter()
                     .map(|b| b.text)
                     .collect::<Vec<_>>()
                     .join("");
+                trace!(response_len = text.len(), "received LLM response");
                 return Ok(text);
             }
 
@@ -136,7 +144,10 @@ impl LlmClient {
                 .unwrap_or_else(|| format!("HTTP {status}"));
 
             if !retryable {
-                bail!("API error ({}): {}", status, err_msg);
+                return Err(LlmError::ApiError {
+                    status: status.as_u16(),
+                    message: err_msg,
+                });
             }
 
             warn!(
@@ -151,32 +162,34 @@ impl LlmClient {
             }
         }
 
-        bail!(
-            "exhausted {} retries: {}",
-            max_attempts,
-            last_err.unwrap_or_default()
-        )
+        Err(LlmError::RetriesExhausted {
+            attempts: max_attempts,
+            last_error: last_err.unwrap_or_default(),
+        })
     }
 
-    pub async fn analyze_file(&self, ctx: &FileContext) -> Result<String> {
+    #[tracing::instrument(name = "llm_file", skip_all, fields(filepath = %ctx.filepath))]
+    pub async fn analyze_file(&self, ctx: &FileContext) -> Result<String, LlmError> {
         let system = prompts::build_system_prompt();
         let user_msg = prompts::build_file_prompt(ctx);
         debug!(filepath = %ctx.filepath, "analyzing file");
         self.send(system, &user_msg).await
     }
 
+    #[tracing::instrument(name = "llm_file_candidates", skip_all, fields(filepath = %ctx.filepath, n_candidates = candidates.len()))]
     pub async fn analyze_file_with_candidates(
         &self,
         ctx: &FileContext,
         candidates: &[Candidate],
-    ) -> Result<String> {
+    ) -> Result<String, LlmError> {
         let system = prompts::build_system_prompt();
         let user_msg = prompts::build_file_prompt_with_candidates(ctx, candidates);
         debug!(filepath = %ctx.filepath, n_candidates = candidates.len(), "analyzing file with candidates");
         self.send(system, &user_msg).await
     }
 
-    pub async fn analyze_project(&self, ctx: &ContestContext) -> Result<String> {
+    #[tracing::instrument(name = "llm_project", skip_all, fields(contest = %ctx.contest_name))]
+    pub async fn analyze_project(&self, ctx: &ContestContext) -> Result<String, LlmError> {
         let system = prompts::build_system_prompt();
         let user_msg = prompts::build_project_prompt(ctx);
         debug!(contest = %ctx.contest_name, "analyzing project");

--- a/src/loader/labels.rs
+++ b/src/loader/labels.rs
@@ -1,16 +1,21 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use crate::error::LoadError;
 
 use super::raw_types::RawLabel;
 
-pub fn load_labels(dataset_dir: &Path) -> Result<HashMap<String, Vec<RawLabel>>> {
+pub fn load_labels(dataset_dir: &Path) -> Result<HashMap<String, Vec<RawLabel>>, LoadError> {
     let path = dataset_dir.join("labels.json");
-    let data =
-        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let data = std::fs::read_to_string(&path).map_err(|e| LoadError::Io {
+        path: path.clone(),
+        source: e,
+    })?;
     let labels: HashMap<String, Vec<RawLabel>> =
-        serde_json::from_str(&data).with_context(|| format!("parsing {}", path.display()))?;
+        serde_json::from_str(&data).map_err(|e| LoadError::Parse {
+            path: path.clone(),
+            source: e,
+        })?;
     Ok(labels)
 }
 

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -9,7 +9,7 @@ pub mod symbolic;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use crate::error::LoadError;
 
 use raw_types::{RawIr, RawStaticAnalysis, RawSymbolicExecution};
 
@@ -20,23 +20,26 @@ pub struct ContestLoader {
 }
 
 impl ContestLoader {
-    pub fn new(contest_path: &Path) -> Result<Self> {
-        anyhow::ensure!(
-            contest_path.exists(),
-            "contest directory not found: {}",
-            contest_path.display()
-        );
+    #[tracing::instrument(name = "loader", skip_all, fields(contest = %contest_path.display()))]
+    pub fn new(contest_path: &Path) -> Result<Self, LoadError> {
+        if !contest_path.exists() {
+            return Err(LoadError::ContestNotFound {
+                path: contest_path.to_path_buf(),
+            });
+        }
         let contest_name = contest_path
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .filter(|n| !n.is_empty())
-            .context("contest_path has no directory name")?;
+            .ok_or(LoadError::InvalidContestPath)?;
 
         let analysis_dir = contest_path
             .parent()
             .and_then(|p| p.parent())
             .map(|p| p.join("analysis").join(&contest_name))
-            .context("contest_path must be at least 2 levels deep")?;
+            .ok_or_else(|| LoadError::ShallowContestPath {
+                path: contest_path.to_path_buf(),
+            })?;
 
         Ok(Self {
             contracts_dir: contest_path.to_path_buf(),
@@ -45,34 +48,40 @@ impl ContestLoader {
         })
     }
 
-    pub fn load_ir(&self) -> Result<RawIr> {
+    pub fn load_ir(&self) -> Result<RawIr, LoadError> {
         self.load_json("ir.json")
     }
 
-    pub fn load_static_analysis(&self) -> Result<RawStaticAnalysis> {
+    pub fn load_static_analysis(&self) -> Result<RawStaticAnalysis, LoadError> {
         self.load_json("static_analysis.json")
     }
 
-    pub fn load_symbolic_execution(&self) -> Result<Option<RawSymbolicExecution>> {
+    pub fn load_symbolic_execution(&self) -> Result<Option<RawSymbolicExecution>, LoadError> {
         let path = self.analysis_dir.join("symbolic_execution.json");
         if !path.exists() {
             return Ok(None);
         }
-        let file =
-            std::fs::File::open(&path).with_context(|| format!("opening {}", path.display()))?;
+        let file = std::fs::File::open(&path).map_err(|e| LoadError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
         let reader = BufReader::new(file);
-        let data = serde_json::from_reader(reader)
-            .with_context(|| format!("parsing {}", path.display()))?;
+        let data = serde_json::from_reader(reader).map_err(|e| LoadError::Parse {
+            path: path.clone(),
+            source: e,
+        })?;
         Ok(Some(data))
     }
 
-    pub fn get_source(&self, filepath: &str) -> Result<String> {
+    pub fn get_source(&self, filepath: &str) -> Result<String, LoadError> {
         let full_path = self.contracts_dir.join(filepath);
-        std::fs::read_to_string(&full_path)
-            .with_context(|| format!("reading source {}", full_path.display()))
+        std::fs::read_to_string(&full_path).map_err(|e| LoadError::Io {
+            path: full_path,
+            source: e,
+        })
     }
 
-    pub fn list_source_files(&self) -> Result<Vec<String>> {
+    pub fn list_source_files(&self) -> Result<Vec<String>, LoadError> {
         scope::load_scope(&self.contracts_dir)
     }
 
@@ -80,24 +89,34 @@ impl ContestLoader {
         &self.contest_name
     }
 
-    fn load_json<T: serde::de::DeserializeOwned>(&self, filename: &str) -> Result<T> {
+    fn load_json<T: serde::de::DeserializeOwned>(&self, filename: &str) -> Result<T, LoadError> {
         let path = self.analysis_dir.join(filename);
-        anyhow::ensure!(path.exists(), "analysis file not found: {}", path.display());
-        let file =
-            std::fs::File::open(&path).with_context(|| format!("opening {}", path.display()))?;
+        if !path.exists() {
+            return Err(LoadError::AnalysisFileNotFound { path });
+        }
+        let file = std::fs::File::open(&path).map_err(|e| LoadError::Io {
+            path: path.clone(),
+            source: e,
+        })?;
         let reader = BufReader::new(file);
-        serde_json::from_reader(reader).with_context(|| format!("parsing {}", path.display()))
+        serde_json::from_reader(reader).map_err(|e| LoadError::Parse { path, source: e })
     }
 }
 
-pub fn list_contests(dataset_dir: &Path) -> Result<Vec<String>> {
+pub fn list_contests(dataset_dir: &Path) -> Result<Vec<String>, LoadError> {
     let contracts_dir = dataset_dir.join("contracts");
     if !contracts_dir.exists() {
         return Ok(vec![]);
     }
     let mut names = Vec::new();
-    for entry in std::fs::read_dir(&contracts_dir)? {
-        let entry = entry?;
+    for entry in std::fs::read_dir(&contracts_dir).map_err(|e| LoadError::Io {
+        path: contracts_dir.clone(),
+        source: e,
+    })? {
+        let entry = entry.map_err(|e| LoadError::Io {
+            path: contracts_dir.clone(),
+            source: e,
+        })?;
         if entry.path().is_dir() {
             if let Some(name) = entry.file_name().to_str() {
                 names.push(name.to_string());

--- a/src/loader/scope.rs
+++ b/src/loader/scope.rs
@@ -1,14 +1,15 @@
 use std::path::Path;
 
-use anyhow::{Context, Result};
-
+use crate::error::LoadError;
 use crate::path_utils::paths_match;
 
-pub fn load_scope(contracts_dir: &Path) -> Result<Vec<String>> {
+pub fn load_scope(contracts_dir: &Path) -> Result<Vec<String>, LoadError> {
     let scope_path = contracts_dir.join("scope.txt");
     if scope_path.exists() {
-        let raw = std::fs::read_to_string(&scope_path)
-            .with_context(|| format!("reading {}", scope_path.display()))?;
+        let raw = std::fs::read_to_string(&scope_path).map_err(|e| LoadError::Io {
+            path: scope_path,
+            source: e,
+        })?;
         let files: Vec<String> = raw
             .lines()
             .map(|l| l.trim().to_string())
@@ -35,12 +36,18 @@ pub fn filter_in_scope(all_files: &[String], scope: &[String]) -> Vec<String> {
         .collect()
 }
 
-fn collect_sol_files(base: &Path, dir: &Path, out: &mut Vec<String>) -> Result<()> {
+fn collect_sol_files(base: &Path, dir: &Path, out: &mut Vec<String>) -> Result<(), LoadError> {
     if !dir.is_dir() {
         return Ok(());
     }
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
+    for entry in std::fs::read_dir(dir).map_err(|e| LoadError::Io {
+        path: dir.to_path_buf(),
+        source: e,
+    })? {
+        let entry = entry.map_err(|e| LoadError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
         let path = entry.path();
         if path.is_dir() {
             collect_sol_files(base, &path, out)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -8,6 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+use vuln_analyzer::error::AnalysisError;
 use vuln_analyzer::llm::LlmClient;
 use vuln_analyzer::pipeline::{self, PipelineConfig};
 
@@ -36,8 +37,39 @@ struct Cli {
     #[arg(long, help = "DEBUG-level tracing, disables progress bars")]
     verbose: bool,
 
+    #[arg(long, help = "Suppress all output except errors")]
+    quiet: bool,
+
+    #[arg(
+        long,
+        default_value = "text",
+        value_enum,
+        help = "Log format: text or json"
+    )]
+    log_format: LogFormat,
+
     #[arg(long, help = "Write per-contest predictions to this directory")]
     output_dir: Option<String>,
+}
+
+#[derive(Clone, clap::ValueEnum)]
+enum LogFormat {
+    Text,
+    Json,
+}
+
+fn write_results(
+    results: &[pipeline::ContestResult],
+    output_dir: Option<&Path>,
+) -> Result<(), vuln_analyzer::error::AnalysisError> {
+    match output_dir {
+        Some(dir) => pipeline::write_output_to_dir(results, dir),
+        None => {
+            let json = pipeline::serialize_predictions(results)?;
+            println!("{json}");
+            Ok(())
+        }
+    }
 }
 
 #[tokio::main]
@@ -46,12 +78,25 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let filter = if cli.verbose {
+    let filter = if cli.quiet {
+        EnvFilter::new("error")
+    } else if cli.verbose {
         EnvFilter::new("debug")
     } else {
-        EnvFilter::from_default_env()
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
     };
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    match cli.log_format {
+        LogFormat::Json => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_env_filter(filter)
+                .init();
+        }
+        LogFormat::Text => {
+            tracing_subscriber::fmt().with_env_filter(filter).init();
+        }
+    }
 
     let cancel = CancellationToken::new();
     let cancel_hook = cancel.clone();
@@ -65,6 +110,7 @@ async fn main() -> Result<()> {
     let config = PipelineConfig {
         dry_run: cli.dry_run,
         verbose: cli.verbose,
+        quiet: cli.quiet,
         output_dir: cli.output_dir.map(PathBuf::from),
         batch_concurrency: 4,
     };
@@ -80,21 +126,21 @@ async fn main() -> Result<()> {
     if cli.batch {
         let dataset_dir = PathBuf::from(&cli.dataset);
         let results = pipeline::run_batch(&dataset_dir, &client, &config, &cancel).await?;
-        pipeline::write_output(&results, config.output_dir.as_deref())?;
-        print_batch_summary(&results, start.elapsed());
+        write_results(&results, config.output_dir.as_deref())?;
+        log_batch_summary(&results, start.elapsed());
     } else if let Some(ref contest) = cli.contest {
         let contest_path = PathBuf::from(contest);
         let result = pipeline::run_contest(&contest_path, &client, &config, &cancel, None).await?;
-        pipeline::write_output(&[result], config.output_dir.as_deref())?;
+        write_results(&[result], config.output_dir.as_deref())?;
     } else {
-        anyhow::bail!("provide --contest <path> or --batch");
+        return Err(AnalysisError::MissingCommand.into());
     }
 
     info!(elapsed = ?start.elapsed(), "total runtime");
     Ok(())
 }
 
-fn print_batch_summary(results: &[pipeline::ContestResult], elapsed: std::time::Duration) {
+fn log_batch_summary(results: &[pipeline::ContestResult], elapsed: std::time::Duration) {
     let total_findings: usize = results.iter().map(|r| r.predictions.len()).sum();
     let total_sa: usize = results.iter().map(|r| r.stats.sa_preds).sum();
     let total_ir: usize = results.iter().map(|r| r.stats.ir_preds).sum();
@@ -102,13 +148,15 @@ fn print_batch_summary(results: &[pipeline::ContestResult], elapsed: std::time::
     let total_sym_killed: usize = results.iter().map(|r| r.stats.symbolic_killed).sum();
     let total_llm: usize = results.iter().map(|r| r.stats.llm_preds).sum();
 
-    eprintln!("\n--- Batch Summary ---");
-    eprintln!("Contests:           {}", results.len());
-    eprintln!("Total findings:     {total_findings}");
-    eprintln!("  SA engine:        {total_sa}");
-    eprintln!("  IR engine:        {total_ir}");
-    eprintln!("  Symbolic confirmed: {total_sym_confirmed}");
-    eprintln!("  Symbolic killed:  {total_sym_killed}");
-    eprintln!("  LLM:              {total_llm}");
-    eprintln!("Elapsed:            {:.1}s", elapsed.as_secs_f64());
+    info!(
+        contests = results.len(),
+        total_findings,
+        sa = total_sa,
+        ir = total_ir,
+        symbolic_confirmed = total_sym_confirmed,
+        symbolic_killed = total_sym_killed,
+        llm = total_llm,
+        elapsed_secs = elapsed.as_secs_f64(),
+        "batch complete"
+    );
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,14 +3,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::{Context, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, info_span, warn};
 
 use crate::engines::{ir_engine, sa_engine, symbolic_engine};
+use crate::error::AnalysisError;
 use crate::llm::LlmClient;
 use crate::loader::context::build_file_context;
 use crate::loader::ir::build_project_summary;
@@ -25,6 +25,7 @@ const MAX_FILE_LLM_CONCURRENCY: usize = 16;
 pub struct PipelineConfig {
     pub dry_run: bool,
     pub verbose: bool,
+    pub quiet: bool,
     pub output_dir: Option<PathBuf>,
     pub batch_concurrency: usize,
 }
@@ -46,13 +47,14 @@ pub struct ContestResult {
     pub stats: PipelineStats,
 }
 
+#[tracing::instrument(name = "contest", skip_all, fields(contest = %contest_path.display()))]
 pub async fn run_contest(
     contest_path: &Path,
     client: &Arc<LlmClient>,
     config: &PipelineConfig,
     cancel: &CancellationToken,
     progress: Option<&ProgressBar>,
-) -> Result<ContestResult> {
+) -> Result<ContestResult, AnalysisError> {
     let start = Instant::now();
     let loader = ContestLoader::new(contest_path)?;
     let contest_name = loader.contest_name().to_string();
@@ -67,35 +69,44 @@ pub async fn run_contest(
     let scope = loader.list_source_files()?;
 
     if cancel.is_cancelled() {
-        anyhow::bail!("cancelled");
+        return Err(AnalysisError::Cancelled);
     }
 
-    // Stage 1: Static analysis classification
     set_message(progress, "SA classify");
     let sa_findings = filter_static_analysis(&sa, &scope);
-    let (sa_preds, sa_candidates) = sa_engine::classify(&sa_findings, &contest_name);
+    let (sa_preds, sa_candidates) = {
+        let _span = info_span!("stage", name = "sa_classify").entered();
+        sa_engine::classify(&sa_findings, &contest_name)
+    };
     stats.sa_preds = sa_preds.len();
     debug!(contest = %contest_name, preds = sa_preds.len(), candidates = sa_candidates.len(), "SA engine done");
 
-    // Stage 2: IR engine analysis
     set_message(progress, "IR analyze");
-    let ir_output = ir_engine::analyze(&ir, &contest_name, &scope);
+    let ir_output = {
+        let _span = info_span!("stage", name = "ir_analyze").entered();
+        ir_engine::analyze(&ir, &contest_name, &scope)
+    };
     stats.ir_preds = ir_output.predictions.len();
     debug!(contest = %contest_name, preds = ir_output.predictions.len(), candidates = ir_output.candidates.len(), "IR engine done");
 
-    // Merge SA + IR outputs
     let mut merged = EngineOutput {
         predictions: sa_preds,
         candidates: sa_candidates,
     };
     merged.merge(ir_output);
 
-    // Stage 3: Symbolic verification
     set_message(progress, "symbolic verify");
     if let Some(ref sx_data) = sx {
+        let _span = info_span!("stage", name = "symbolic_verify").entered();
         let verification = symbolic_engine::verify(sx_data, &merged.candidates, &contest_name);
         stats.symbolic_confirmed = verification.confirmed.len();
         stats.symbolic_killed = verification.killed.len();
+        if !verification.killed.is_empty() {
+            warn!(
+                killed = verification.killed.len(),
+                "symbolic engine killed candidates"
+            );
+        }
         debug!(
             contest = %contest_name,
             confirmed = verification.confirmed.len(),
@@ -105,15 +116,13 @@ pub async fn run_contest(
         );
 
         merged.predictions.extend(verification.confirmed);
-        // Replace candidates with only inconclusive ones (killed are dropped)
         merged.candidates = verification.inconclusive;
     }
 
     if cancel.is_cancelled() {
-        anyhow::bail!("cancelled");
+        return Err(AnalysisError::Cancelled);
     }
 
-    // Stage 4: LLM analysis (skip if dry-run)
     if config.dry_run {
         info!(contest = %contest_name, "dry-run: skipping LLM stages");
         let deduped = deduplicate(merged.predictions);
@@ -137,9 +146,7 @@ pub async fn run_contest(
 
     let mut file_contexts = Vec::new();
     for filepath in &scope {
-        let source = loader
-            .get_source(filepath)
-            .with_context(|| format!("reading source for {filepath}"))?;
+        let source = loader.get_source(filepath)?;
         let ctx = build_file_context(filepath, &source, &ir, sx.as_ref(), &sa_findings);
         file_contexts.push(ctx);
     }
@@ -201,10 +208,9 @@ pub async fn run_contest(
     }
 
     if cancel.is_cancelled() {
-        anyhow::bail!("cancelled");
+        return Err(AnalysisError::Cancelled);
     }
 
-    // Stage 5: Project-level LLM
     set_message(progress, "LLM project analysis");
     let project_summary = build_project_summary(&ir, &sa_findings, &scope);
     let project_ctx = ContestContext {
@@ -245,20 +251,23 @@ pub async fn run_contest(
     })
 }
 
+#[tracing::instrument(name = "batch", skip_all, fields(dataset = %dataset_dir.display()))]
 pub async fn run_batch(
     dataset_dir: &Path,
     client: &Arc<LlmClient>,
     config: &PipelineConfig,
     cancel: &CancellationToken,
-) -> Result<Vec<ContestResult>> {
+) -> Result<Vec<ContestResult>, AnalysisError> {
     let contests = list_contests(dataset_dir)?;
     if contests.is_empty() {
-        anyhow::bail!("no contests found in {}", dataset_dir.display());
+        return Err(AnalysisError::NoContests {
+            path: dataset_dir.to_path_buf(),
+        });
     }
     info!(count = contests.len(), "running batch mode");
 
     let semaphore = Arc::new(Semaphore::new(config.batch_concurrency));
-    let mp = if config.verbose {
+    let mp = if config.verbose || config.quiet {
         None
     } else {
         Some(MultiProgress::new())
@@ -319,27 +328,21 @@ pub async fn run_batch(
     Ok(results)
 }
 
-pub fn write_output(results: &[ContestResult], output_dir: Option<&Path>) -> Result<()> {
-    match output_dir {
-        Some(dir) => {
-            for result in results {
-                let contest_dir = dir.join(&result.contest_name);
-                std::fs::create_dir_all(&contest_dir)
-                    .with_context(|| format!("creating {}", contest_dir.display()))?;
-                let path = contest_dir.join("predictions.json");
-                let json = serde_json::to_string_pretty(&result.predictions)?;
-                std::fs::write(&path, &json)
-                    .with_context(|| format!("writing {}", path.display()))?;
-                info!(path = %path.display(), count = result.predictions.len(), "wrote predictions");
-            }
-        }
-        None => {
-            let all_preds: Vec<&Prediction> = results.iter().flat_map(|r| &r.predictions).collect();
-            let json = serde_json::to_string_pretty(&all_preds)?;
-            println!("{json}");
-        }
+pub fn write_output_to_dir(results: &[ContestResult], dir: &Path) -> Result<(), AnalysisError> {
+    for result in results {
+        let contest_dir = dir.join(&result.contest_name);
+        std::fs::create_dir_all(&contest_dir).map_err(AnalysisError::OutputWrite)?;
+        let path = contest_dir.join("predictions.json");
+        let json = serde_json::to_string_pretty(&result.predictions)?;
+        std::fs::write(&path, &json).map_err(AnalysisError::OutputWrite)?;
+        info!(path = %path.display(), count = result.predictions.len(), "wrote predictions");
     }
     Ok(())
+}
+
+pub fn serialize_predictions(results: &[ContestResult]) -> Result<String, AnalysisError> {
+    let all_preds: Vec<&Prediction> = results.iter().flat_map(|r| &r.predictions).collect();
+    Ok(serde_json::to_string_pretty(&all_preds)?)
 }
 
 fn set_message(progress: Option<&ProgressBar>, msg: &str) {

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 use serde_json::Value;
-use tracing::warn;
+use tracing::{trace, warn};
 
 use crate::config::MIN_CONFIDENCE;
 use crate::types::{Prediction, Severity, VulnType};
@@ -31,6 +31,7 @@ const TOKEN_STRONG: &[&str] = &[
 const TOKEN_CONTEXT: &[&str] = &["refund", "reward", "mint", "burn"];
 
 pub fn parse_json_response(text: &str) -> Vec<Value> {
+    trace!(input_len = text.len(), "parsing JSON response");
     if let Some(cap) = RE_CODE_BLOCK.captures(text) {
         if let Ok(parsed) = serde_json::from_str::<Vec<Value>>(&cap[1]) {
             if parsed.iter().all(|v| v.is_object()) {


### PR DESCRIPTION
Replace anyhow::Result with domain-specific error types (LoadError, LlmError, AnalysisError) using thiserror so callers can match on error variants. Add #[instrument] spans on pipeline stages, engines, loader, and LLM client. Wire --quiet and --log-format json flags into the CLI with reworked tracing subscriber. Replace eprintln batch summary with structured info! logging. Move println from library code into the binary.